### PR TITLE
add portfolioDetail page and corresponding react route to render port…

### DIFF
--- a/app/src/App/index.js
+++ b/app/src/App/index.js
@@ -5,6 +5,8 @@ import { Routes, Route } from "react-router-dom";
 import AddPortfolio from "../AddPortfolio";
 import Discover from "../Discover";
 import MyStocks from "../MyStocks";
+import Portfolios from "../MyStocks/Portfolios";
+import PortfolioDetail from "../PortfolioDetail";
 import StockDetail from "../StockDetail";
 import useApi from "../auth/useApi";
 import useAuth0 from "../auth/useAuth0";
@@ -89,6 +91,14 @@ const App = () => {
                 {...{ updateWatchListButton }}
               />
             }
+          />
+          <Route
+            path="/portfolios"
+            element={<Protected component={Portfolios} />}
+          />
+          <Route
+            path="/:portfolio_id"
+            element={<Protected component={PortfolioDetail} />}
           />
           <Route
             path="/addPortfolio"

--- a/app/src/MyStocks/Portfolios.js
+++ b/app/src/MyStocks/Portfolios.js
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import { Link } from "react-router-dom";
+
 import useApi from "../auth/useApi";
 
 const Portfolios = () => {
@@ -16,10 +18,6 @@ const Portfolios = () => {
     loadPortfolios();
   };
 
-  const handleViewChart = () => {
-    //
-  };
-
   React.useEffect(() => {
     if (!loading) {
       loadPortfolios();
@@ -33,42 +31,44 @@ const Portfolios = () => {
   ) : (
     <section>
       <h2>Portfolios</h2>
-      {portfolios.map((portfolio) => (
-        <div key={portfolio.portfolio_id}>
-          <details>
-            <summary>Portfolio {portfolio.portfolio_id}</summary>
-            <p>
-              Historical time period:
-              {portfolio.time_period}
-            </p>
-            <p>Initial Amount: ${portfolio.portfolio_values[0]}</p>
-            <PortfolioStocks {...{ portfolio }} />
-          </details>
-          <button
-            type="button"
-            onClick={() => handleDeletePortfolio(portfolio)}
-          >
-            Delete Portfolio
-          </button>
-          <button type="button" onClick={() => handleViewChart(portfolio)}>
-            View Historical Performance
-          </button>
-        </div>
-      ))}
+      {portfolios.map(
+        ({ portfolio_id, portfolio_name, time_period, portfolio_values }) => (
+          <div key={portfolio_id}>
+            <details>
+              <summary>
+                {portfolio_name ? portfolio_name : "Portfolio " + portfolio_id}
+              </summary>
+              <p>
+                Historical time period:
+                {time_period}
+              </p>
+              <p>Initial Amount: ${portfolio_values[0]}</p>
+              <PortfolioStocks {...{ portfolio_id }} />
+            </details>
+            <button
+              type="button"
+              onClick={() => handleDeletePortfolio(portfolio_id)}
+            >
+              Delete Portfolio
+            </button>
+            <Link to={`/${portfolio_id}`}>
+              <button type="button">View Historical Performance</button>
+            </Link>
+          </div>
+        ),
+      )}
     </section>
   );
 };
 
-const PortfolioStocks = ({ portfolio }) => {
+const PortfolioStocks = ({ portfolio_id }) => {
   const { loading, apiClient } = useApi();
   const [portfolioStocks, setPortfolioStocks] = React.useState([]);
 
   const loadPortfolioStocks = React.useCallback(
     async () =>
-      setPortfolioStocks(
-        await apiClient.getPortfolioStocks(portfolio.portfolio_id),
-      ),
-    [apiClient, portfolio.portfolio_id],
+      setPortfolioStocks(await apiClient.getPortfolioStocks(portfolio_id)),
+    [apiClient, portfolio_id],
   );
 
   React.useEffect(() => {
@@ -79,11 +79,12 @@ const PortfolioStocks = ({ portfolio }) => {
 
   return (
     <>
-      <p>Holdings for portfolio {portfolio.portfolio_id} </p>
+      <p>Holdings for portfolio {portfolio_id} </p>
       <ul>
         {portfolioStocks.map((stock) => (
           <li key={stock.ticker}>
-            {stock.ticker} | {stock.allocation}%
+            <Link to={`/stocks/${stock.ticker}`}>{stock.ticker} </Link> |{" "}
+            {stock.allocation}%
           </li>
         ))}
       </ul>

--- a/app/src/MyStocks/Portfolios.js
+++ b/app/src/MyStocks/Portfolios.js
@@ -52,7 +52,7 @@ const Portfolios = () => {
               Delete Portfolio
             </button>
             <Link to={`/${portfolio_id}`}>
-              <button type="button">View Historical Performance</button>
+              <button type="button">Portfolio Historical Performance</button>
             </Link>
           </div>
         ),

--- a/app/src/PortfolioDetail/index.js
+++ b/app/src/PortfolioDetail/index.js
@@ -6,10 +6,26 @@ import useApi from "../auth/useApi";
 
 const PortfolioDetail = () => {
   const { loading, apiClient } = useApi();
-  const [portfolioStocks, setPortfolioStocks] = React.useState();
+  const [portfolio, setPortfolio] = React.useState();
+  const [portfolioStocks, setPortfolioStocks] = React.useState([]);
   const [error, setError] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState("");
   const { portfolio_id } = useParams();
+
+  const loadPortfolio = React.useCallback(
+    () =>
+      apiClient
+        .getPortfolio(portfolio_id)
+        .then((response) => {
+          setPortfolio(response);
+          setError(false);
+        })
+        .catch((err) => {
+          setError(true);
+          setErrorMessage(err.message);
+        }),
+    [apiClient, portfolio_id],
+  );
 
   const loadPortfolioStocks = React.useCallback(
     () =>
@@ -27,16 +43,21 @@ const PortfolioDetail = () => {
   );
 
   React.useEffect(() => {
+    portfolio_id !== undefined && !loading && loadPortfolio();
+  }, [loading, portfolio_id, loadPortfolio]);
+
+  React.useEffect(() => {
     portfolio_id !== undefined && !loading && loadPortfolioStocks();
   }, [loading, portfolio_id, loadPortfolioStocks]);
 
   return error === true ? (
     <p>{errorMessage}</p>
-  ) : !portfolioStocks ? (
+  ) : !portfolio || !portfolioStocks ? (
     <p>Loading...</p>
   ) : (
     <>
       <p>This is portfolio detail page for portfolio {portfolio_id}</p>
+      <p>Historical holding period: {portfolio.time_period}</p>
       <ul>
         {portfolioStocks.map((stock) => (
           <li key={stock.ticker}>

--- a/app/src/PortfolioDetail/index.js
+++ b/app/src/PortfolioDetail/index.js
@@ -1,0 +1,52 @@
+import * as React from "react";
+
+import { useParams, Link } from "react-router-dom";
+
+import useApi from "../auth/useApi";
+
+const PortfolioDetail = () => {
+  const { loading, apiClient } = useApi();
+  const [portfolioStocks, setPortfolioStocks] = React.useState();
+  const [error, setError] = React.useState(false);
+  const [errorMessage, setErrorMessage] = React.useState("");
+  const { portfolio_id } = useParams();
+
+  const loadPortfolioStocks = React.useCallback(
+    () =>
+      apiClient
+        .getPortfolioStocks(portfolio_id)
+        .then((response) => {
+          setPortfolioStocks(response);
+          setError(false);
+        })
+        .catch((err) => {
+          setError(true);
+          setErrorMessage(err.message);
+        }),
+    [apiClient, portfolio_id],
+  );
+
+  React.useEffect(() => {
+    portfolio_id !== undefined && !loading && loadPortfolioStocks();
+  }, [loading, portfolio_id, loadPortfolioStocks]);
+
+  return error === true ? (
+    <p>{errorMessage}</p>
+  ) : !portfolioStocks ? (
+    <p>Loading...</p>
+  ) : (
+    <>
+      <p>This is portfolio detail page for portfolio {portfolio_id}</p>
+      <ul>
+        {portfolioStocks.map((stock) => (
+          <li key={stock.ticker}>
+            <Link to={`/stocks/${stock.ticker}`}>{stock.ticker} </Link> |{" "}
+            {stock.allocation}%
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+export default PortfolioDetail;

--- a/app/src/auth/useApi.js
+++ b/app/src/auth/useApi.js
@@ -9,8 +9,9 @@ const makeApi = (accessToken) => {
     getStockQuote: (ticker) => _get(`/api/market/stock/${ticker}/quote`),
     getWatchlist: () => _get("/api/watchlist"),
     getPortfolios: () => _get("/api/portfolios"),
+    getPortfolio: (portfolioID) => _get(`/api/portfolios/${portfolioID}`),
     getPortfolioStocks: (portfolioID) =>
-      _get(`api/portfolios/${portfolioID}/stocks`),
+      _get(`/api/portfolios/${portfolioID}/stocks`),
     updateStockQuotes: (stocks) => _post("/api/stocks/update-quotes", stocks),
     addStockToWatchlist: (ticker) => _post("/api/watchlist/stocks", { ticker }),
     addOrUpdateUser: (user) => _post("/api/users", { user }),

--- a/app/src/auth/useApi.js
+++ b/app/src/auth/useApi.js
@@ -39,15 +39,6 @@ const makeApi = (accessToken) => {
 
   const _delete = (url) => _fetch(url, { method: "DELETE" });
 
-  // const _fetch = (url, options) =>
-  //   fetch(url, {
-  //     ...options,
-  //     headers: {
-  //       ...(options?.headers ?? {}),
-  //       Authorization: `Bearer ${accessToken}`,
-  //     },
-  //   });
-
   const _fetch = async (url, options) => {
     const response = await fetch(url, {
       ...options,

--- a/server/src/db.mjs
+++ b/server/src/db.mjs
@@ -46,8 +46,8 @@ export const addStockToWatchlist = (sub, ticker) =>
 
 export const addUserPortfolio = (sub, portfolio) =>
   db.one(
-    `INSERT INTO user_portfolio(user_id, time_period, portfolio_values)
-    VALUES((SELECT id FROM users WHERE sub=$<sub>), $<timePeriod>, ARRAY [$<initialAmount>])
+    `INSERT INTO user_portfolio(user_id, portfolio_name, time_period, portfolio_values)
+    VALUES((SELECT id FROM users WHERE sub=$<sub>), $<portfolioName>, $<timePeriod>, ARRAY [$<initialAmount>])
       RETURNING *`,
     { sub, ...portfolio },
   );

--- a/server/src/db.mjs
+++ b/server/src/db.mjs
@@ -18,6 +18,11 @@ export const getPortfolios = (sub) =>
     { sub },
   );
 
+export const getPortfolio = (portfolioID) =>
+  db.one("SELECT * FROM user_portfolio WHERE portfolio_id=$<portfolioID>", {
+    portfolioID,
+  });
+
 export const getPortfolioStocks = (portfolioID) =>
   db.any(
     "SELECT * FROM portfolio_stock ps LEFT JOIN user_portfolio up on ps.portfolio_id = up.portfolio_id WHERE up.portfolio_id = $<portfolioID>",

--- a/server/src/portfolioRouter.mjs
+++ b/server/src/portfolioRouter.mjs
@@ -9,6 +9,11 @@ router.get("/", async (request, response) => {
   response.json(portfolios);
 });
 
+router.get("/:portfolioID", async (request, response) => {
+  const portfolio = await db.getPortfolio(request.params.portfolioID);
+  response.json(portfolio);
+});
+
 router.get("/:portfolioID/stocks", async (request, response) => {
   const portfolioStocks = await db.getPortfolioStocks(
     request.params.portfolioID,


### PR DESCRIPTION
## Overview

Add portfolio detail page and corresponding react route to prepare for rendering portfolio charts.

## Feedback Requested

I am getting this error when I set react route of the portfolio detail page to be `/portfolios/:portfolio_id` (actually adding anything before `/:portfolio_id` would return this 404 error). Currently it only renders correctly if I set react route to `/:portfolio_id`.

![Screen Shot 2021-10-29 at 11 16 10 PM](https://user-images.githubusercontent.com/11522217/139521231-b493fef8-0e64-4959-af5a-31a66d8f6a5a.png)
